### PR TITLE
Add BTCRelay Interface Contract

### DIFF
--- a/BlockhashFetch.sol
+++ b/BlockhashFetch.sol
@@ -1,8 +1,8 @@
 contract BTCRelay {
-    function getBlockHeader(uint blockHash) returns (bytes32[3]);
-    function getLastBlockHeight() returns (uint);
-    function getBlockchainHead() returns (uint);
-    function getFeeAmount(uint blockHash) returns (uint);
+    function getBlockHeader(int blockHash) returns (bytes32[3]);
+    function getLastBlockHeight() returns (int);
+    function getBlockchainHead() returns (int);
+    function getFeeAmount(int blockHash) returns (int);
 }
 
 
@@ -16,9 +16,9 @@ contract BlockhashFetch {
   }
 
 
-  function getPrevHash(uint prevHash) returns (bytes32 hash){
+  function getPrevHash(int prevHash) returns (bytes32 hash){
 
-    uint fee = relay.getFeeAmount(prevHash);
+    uint fee = uint(relay.getFeeAmount(prevHash));
     bytes32 head = relay.getBlockHeader.value(fee)(prevHash)[2];
     bytes32 temp;
 

--- a/BlockhashFetch.sol
+++ b/BlockhashFetch.sol
@@ -9,16 +9,20 @@ contract BTCRelay {
 contract BlockhashFetch {
 
   BTCRelay relay;
-  mapping(uint => uint) blockHashes;
+  mapping(int => int) blockHashes; //Cache blockhashes
 
   function BlockhashFetch(address _relay){
     relay = BTCRelay(_relay);
   }
 
 
-  function getPrevHash(int currentHash) returns (bytes32 parentHash){
+  function getPrevHash(int currentHash) returns (int parentHash, uint fee){
 
-    uint fee = uint(relay.getFeeAmount(currentHash));
+    if(blockHashes[currentHash] != 0) return (blockHashes[currentHash], 0);
+
+    fee = uint(relay.getFeeAmount(currentHash));
+
+    if(fee > this.balance) return (0,0);
     bytes32 head = relay.getBlockHeader.value(fee)(currentHash)[2];
     bytes32 temp;
 
@@ -28,11 +32,26 @@ contract BlockhashFetch {
         temp := mload(add(x,0x04))
     }
 
-    for(uint i; i<32; i++){
-      parentHash = parentHash | bytes32(uint(temp[i]) * (0x100**i));
+    for(int i; i<32; i++){
+      parentHash = parentHash | int(temp[uint(i)]) * (0x100**i);
     }
+
+    blockHashes[currentHash] = int(parentHash);
   }
 
+  function getBlockHash (int blockHeight) returns (bytes32, uint totalFee){
+    int highestBlock = relay.getLastBlockHeight();
+    int currentHash = relay.getBlockchainHead();
+    if(blockHeight > highestBlock) return (0x0, 0);
 
+    for(int i; i < highestBlock - blockHeight; i++){
+      if(currentHash == 0) return (0x0,totalFee);
+      uint fee;
+      (currentHash, fee) = getPrevHash(currentHash);
+      totalFee += fee;
+    }
+
+    return (bytes32(currentHash), totalFee);
+  }
 
 }

--- a/BlockhashFetch.sol
+++ b/BlockhashFetch.sol
@@ -16,10 +16,10 @@ contract BlockhashFetch {
   }
 
 
-  function getPrevHash(int prevHash) returns (bytes32 hash){
+  function getPrevHash(int currentHash) returns (bytes32 parentHash){
 
-    uint fee = uint(relay.getFeeAmount(prevHash));
-    bytes32 head = relay.getBlockHeader.value(fee)(prevHash)[2];
+    uint fee = uint(relay.getFeeAmount(currentHash));
+    bytes32 head = relay.getBlockHeader.value(fee)(currentHash)[2];
     bytes32 temp;
 
     assembly {
@@ -29,11 +29,8 @@ contract BlockhashFetch {
     }
 
     for(uint i; i<32; i++){
-      hash = hash | bytes32(uint(temp[i]) * (0x100**i));
+      parentHash = parentHash | bytes32(uint(temp[i]) * (0x100**i));
     }
-
-
-    return hash;
   }
 
 

--- a/BlockhashFetch.sol
+++ b/BlockhashFetch.sol
@@ -1,0 +1,41 @@
+contract BTCRelay {
+    function getBlockHeader(uint blockHash) returns (bytes32[3]);
+    function getLastBlockHeight() returns (uint);
+    function getBlockchainHead() returns (uint);
+    function getFeeAmount(uint blockHash) returns (uint);
+}
+
+
+contract BlockhashFetch {
+
+  BTCRelay relay;
+  mapping(uint => uint) blockHashes;
+
+  function BlockhashFetch(address _relay){
+    relay = BTCRelay(_relay);
+  }
+
+
+  function getPrevHash(uint prevHash) returns (bytes32 hash){
+
+    uint fee = relay.getFeeAmount(prevHash);
+    bytes32 head = relay.getBlockHeader.value(fee)(prevHash)[2];
+    bytes32 temp;
+
+    assembly {
+        let x := mload(0x40)
+        mstore(x,head)
+        temp := mload(add(x,0x04))
+    }
+
+    for(uint i; i<32; i++){
+      hash = hash | bytes32(uint(temp[i]) * (0x100**i));
+    }
+
+
+    return hash;
+  }
+
+
+
+}

--- a/RoundLib.sol
+++ b/RoundLib.sol
@@ -1,9 +1,3 @@
-contract BTCRelay {
-    function getBlockHeader(uint blockHash) returns (uint);
-    function getLastBlockHeight() returns (uint);
-    function getBlockchainHead() returns (uint);
-}
-
 library RoundLib{
 
   enum Phase {Buy, Wait, Claim, Ended}


### PR DESCRIPTION
# Changes:
- Add contract to automatically fetch and process block hashes from BTC Relay

Requires fee to paid for _each_ block that is iterated through, and is quite gas intensive. Caches blockhashes to prevent double paying. If there's a missing block hash or contract runs out of funds, it gracefully finishes caching successfully retrieved hashes then returns 0.
